### PR TITLE
Add chunk using the api to ensure correct naming

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,10 @@ class MergeIntoFile {
           newFileNameHashed = newFileName.replace(/(\.min)?\.\w+(\.map)?$/, suffix => `-${hashPart}${suffix}`);
 
           const fileId = newFileName.replace(/\.map$/, '').replace(/\.\w+$/, '');
-          const chunk = new Chunk(fileId);
+          const chunk = compilation.addChunk(fileId);
           chunk.id = fileId;
           chunk.ids = [chunk.id];
           chunk.files.push(newFileNameHashed);
-          compilation.chunks.push(chunk);
         }
         generatedFiles[newFileName] = newFileNameHashed
         compilation.assets[newFileNameHashed] = {   // eslint-disable-line no-param-reassign


### PR DESCRIPTION
The webpack compilation object maintains a namedChunks and a chunks list.
Only by using compilation.addChunk we can ensure that these lists are updated correctly.
See the compilation.addChunk function for details: https://github.com/webpack/webpack/blob/b93048643fe74de2a6931755911da1212df55897/lib/Compilation.js#L1520