### PR TITLE
added transformFileName parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,29 @@ default: false
 set `true` to append version hash before file extension.
 
 you can get names of generated files mapped to original by passing callback function as second argument to plugin: 
-```
+```javascript
 new MergeIntoSingle({ ... }, filesMap => { ... }),
+```
+
+#### transformFileName
+default: undefined
+
+also you can pass function for change output file name with hash
+```javascript
+new MergeIntoSingle({
+  ...,
+  transformFileName: (fileNameBase, extension, hash) => `${fileName}.[${hash}]${extension}`,
+  // bundle.[somehash].js
+}),
+
+//or
+
+new MergeIntoSingle({
+  ...,
+  transformFileName: (fileNameBase, extension, hash) => `${fileNameBase}${extension}?hash=${hash}`,
+  // bundle.js?hash=somehash
+}),
+
 ```
 
 #### encoding

--- a/index.node6-compatible.js
+++ b/index.node6-compatible.js
@@ -59,7 +59,14 @@ class MergeIntoFile {
   }
 
   run(compilation, callback) {
-    const { files, transform, encoding, hash, chunks } = this.options;
+    const {
+      files,
+      transform,
+      encoding,
+      chunks,
+      hash,
+      transformFileName
+    } = this.options;
     if (chunks && compilation.chunks && compilation.chunks.filter(chunk => chunks.indexOf(chunk.name) >= 0 && chunk.rendered).length === 0) {
       callback();
       return;
@@ -97,17 +104,31 @@ class MergeIntoFile {
         const resultsFiles = yield fileTransform.dest(content);
         Object.keys(resultsFiles).forEach(function (newFileName) {
           let newFileNameHashed = newFileName;
-          if (hash) {
+          const hasTransformFileNameFn = typeof transformFileName === 'function';
+
+          if (hash || hasTransformFileNameFn) {
             const hashPart = MergeIntoFile.getHashOfRelatedFile(compilation.assets, newFileName) || revHash(resultsFiles[newFileName]);
-            newFileNameHashed = newFileName.replace(/(\.min)?\.\w+(\.map)?$/, function (suffix) {
-              return `-${hashPart}${suffix}`;
-            });
+
+            if (hasTransformFileNameFn) {
+              const extensionPattern = /\.[^.]*$/g;
+              const fileNameBase = newFileName.replace(extensionPattern, '');
+              const [extension] = newFileName.match(extensionPattern);
+
+              newFileNameHashed = transformFileName(fileNameBase, extension, hashPart);
+            } else {
+              newFileNameHashed = newFileName.replace(/(\.min)?\.\w+(\.map)?$/, function (suffix) {
+                return `-${hashPart}${suffix}`;
+              });
+            }
 
             const fileId = newFileName.replace(/\.map$/, '').replace(/\.\w+$/, '');
-            const chunk = compilation.addChunk(fileId);
-            chunk.id = fileId;
-            chunk.ids = [chunk.id];
-            chunk.files.push(newFileNameHashed);
+
+            if (typeof compilation.addChunk === 'function') {
+              const chunk = compilation.addChunk(fileId);
+              chunk.id = fileId;
+              chunk.ids = [chunk.id];
+              chunk.files.push(newFileNameHashed);
+            }
           }
           generatedFiles[newFileName] = newFileNameHashed;
           compilation.assets[newFileNameHashed] = { // eslint-disable-line no-param-reassign

--- a/index.test.js
+++ b/index.test.js
@@ -111,4 +111,37 @@ describe('MergeIntoFile', () => {
       },
     });
   });
+
+  it('should succeed merging using transform file name function', (done) => {
+    const mockHash = 'xyz';
+    const instance = new MergeIntoSingle({
+      files: {
+        'script.js': [
+          'file1.js',
+          'file2.js',
+        ],
+        'other.deps.js': [
+          'file1.js',
+        ],
+        'style.css': [
+          '*.css',
+        ],
+      },
+      transformFileName: (fileNameBase, extension) => `${fileNameBase}${extension}?hash=${mockHash}`,
+    });
+    instance.apply({
+      plugin: (event, fun) => {
+        const obj = {
+          assets: {},
+        };
+        fun(obj, (err) => {
+          expect(err).toEqual(undefined);
+          expect(obj.assets[`script.js?hash=${mockHash}`]).toBeDefined();
+          expect(obj.assets[`other.deps.js?hash=${mockHash}`]).toBeDefined();
+          expect(obj.assets[`style.css?hash=${mockHash}`]).toBeDefined();
+          done();
+        });
+      },
+    });
+  });
 });


### PR DESCRIPTION
Hey. I have some trouble with hardcoding file names (with hashes), because if I'll save html page as static file on server (in my case) and after this I'll change js or css file then filenames will also change and static html won't work. To avoid this situation I added transformFileName parameter. It's simple function that return name of file. And we can make file names something like this ```'bundle.min.js?hash=12345'``` It's reason for this pull request. I hope you'll accept it. Thanks a lot for plugin!)