### PR TITLE
Add separator as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ default: undefined
 
 array of entry points (strings) for which this plugin should run only
 
+#### separator
+
+default: '\n'
+
+string used between files when joining them together
+
 ### Working Example
 
 working example already included in project.

--- a/index.js
+++ b/index.js
@@ -76,10 +76,11 @@ class MergeIntoFile {
       }
     });
     const finalPromises = filesCanonical.map(async (fileTransform) => {
+      const { separator = '\n'} = this.options;
       const listOfLists = await Promise.all(fileTransform.src.map(path => listFiles(path, null)));
       const flattenedList = Array.prototype.concat.apply([], listOfLists);
       const filesContentPromises = flattenedList.map(path => readFile(path, encoding || 'utf-8'));
-      const content = await joinContent(filesContentPromises, '\n');
+      const content = await joinContent(filesContentPromises, separator);
       const resultsFiles = await fileTransform.dest(content);
       for (const resultsFile in resultsFiles) {
         if (typeof resultsFiles[resultsFile] === 'object') {

--- a/index.node6-compatible.js
+++ b/index.node6-compatible.js
@@ -59,6 +59,8 @@ class MergeIntoFile {
   }
 
   run(compilation, callback) {
+    var _this = this;
+
     const {
       files,
       transform,
@@ -93,6 +95,7 @@ class MergeIntoFile {
     });
     const finalPromises = filesCanonical.map((() => {
       var _ref3 = _asyncToGenerator(function* (fileTransform) {
+        const { separator = '\n' } = _this.options;
         const listOfLists = yield Promise.all(fileTransform.src.map(function (path) {
           return listFiles(path, null);
         }));
@@ -100,7 +103,7 @@ class MergeIntoFile {
         const filesContentPromises = flattenedList.map(function (path) {
           return readFile(path, encoding || 'utf-8');
         });
-        const content = yield joinContent(filesContentPromises, '\n');
+        const content = yield joinContent(filesContentPromises, separator);
         const resultsFiles = yield fileTransform.dest(content);
         for (const resultsFile in resultsFiles) {
           if (typeof resultsFiles[resultsFile] === 'object') {

--- a/index.test.js
+++ b/index.test.js
@@ -52,6 +52,30 @@ describe('MergeIntoFile', () => {
     });
   });
 
+  it('should succeed merging using mock content with a custom separator', (done) => {
+    const instance = new MergeIntoSingle({
+      separator: '\n;\n',
+      files: {
+        'script.js': [
+          'file1.js',
+          'file2.js',
+        ]
+      },
+    });
+    instance.apply({
+      plugin: (event, fun) => {
+        const obj = {
+          assets: {},
+        };
+        fun(obj, (err) => {
+          expect(err).toEqual(undefined);
+          expect(obj.assets['script.js'].source()).toEqual('FILE_1_TEXT\n;\nFILE_2_TEXT');
+          done();
+        });
+      },
+    });
+  });
+
   it('should succeed merging using mock content with transform', (done) => {
     const instance = new MergeIntoSingle({
       files: {


### PR DESCRIPTION
Having separator as an option allows for customizing what is used to separate files when bundling. For example it is safe to add a semicolon to ensure files don't cause issues when joined together. https://stackoverflow.com/a/7145534
