### PR TITLE
Fix Webpack 5 deprecation warning: Chunk.files is now a Set

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,11 @@ class MergeIntoFile {
             const chunk = compilation.addChunk(fileId);
             chunk.id = fileId;
             chunk.ids = [chunk.id];
-            chunk.files.push(newFileNameHashed);
+            if (chunk.files instanceof Set) {
+              chunk.files.add(newFileNameHashed);
+            } else {
+              chunk.files.push(newFileNameHashed);
+            }
           }
         }
         generatedFiles[newFileName] = newFileNameHashed;

--- a/index.node6-compatible.js
+++ b/index.node6-compatible.js
@@ -267,7 +267,12 @@ var MergeIntoFile = /*#__PURE__*/function () {
                         var chunk = compilation.addChunk(fileId);
                         chunk.id = fileId;
                         chunk.ids = [chunk.id];
-                        chunk.files.push(newFileNameHashed);
+
+                        if (chunk.files instanceof Set) {
+                          chunk.files.add(newFileNameHashed);
+                        } else {
+                          chunk.files.push(newFileNameHashed);
+                        }
                       }
                     }
 


### PR DESCRIPTION
This contribution solves the deprecation warning caused by [the transformation into a Set of Chunk.files in Webpack 5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#arrays-to-sets).

The warning should not been visible anymore
```
[DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET_PUSH] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'push' is deprecated)
```